### PR TITLE
fix: semantic release job runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Update CHANGELOG.md [skip ci]
 - Update CHANGELOG.md [skip ci]
 - Update module source references and target_lag validation
+- Update CHANGELOG.md [skip ci]
 
 ### 🎨 Styling
 
@@ -21,3 +22,4 @@
 ### ⚙️ Miscellaneous Tasks
 
 - Expand test coverage and add environment variable configuration
+- Update package metadata for dynamic table module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "terraform-snowflake-warehouse",
+    "name": "terraform-snowflake-dynamic-table",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "terraform-snowflake-warehouse",
+            "name": "terraform-snowflake-dynamic-table",
             "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "terraform-snowflake-warehouse",
+    "name": "terraform-snowflake-dynamic-table",
     "version": "0.0.0",
     "description": "Terraform module for creating and managing Snowflake warehouses with Semantic Release support.",
     "license": "MIT",
@@ -20,7 +20,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-warehouse.git"
+        "url": "git+https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-dynamic-table.git"
     },
     "keywords": [
         "terraform",
@@ -29,7 +29,7 @@
         "infrastructure-as-code"
     ],
     "bugs": {
-        "url": "https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-warehouse/issues"
+        "url": "https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-dynamic-table/issues"
     },
-    "homepage": "https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-warehouse#readme"
+    "homepage": "https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-dynamic-table#readme"
 }


### PR DESCRIPTION
This pull request updates the package metadata and documentation to reflect the transition from managing Snowflake warehouses to managing dynamic tables. The most significant changes involve renaming the package and updating repository references.

**Package metadata updates:**

* Renamed the package in `package.json` from `terraform-snowflake-warehouse` to `terraform-snowflake-dynamic-table`.
* Updated the repository URL, bugs URL, and homepage fields in `package.json` to point to the new dynamic table repository. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23-R23) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32-R34)

**Documentation updates:**

* Updated the `CHANGELOG.md` to reflect the package metadata changes for the dynamic table module. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR25) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16)